### PR TITLE
Correct license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
       "url": "https://github.com/gcxfd"
     }
   ],
-  "license": "AGPL-3.0-or-later",
+  "license": "MIT",
   "dependencies": {
     "bindings": "^1.5.0",
     "nan": "^2.17.0",


### PR DESCRIPTION
Tools such as Tidelift use the package.json file to warn of restrictive licenses. Correcting the value to match LICENSE and readme files.